### PR TITLE
Fix path traversal issue and readme typo

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const app = require('express')();
 // const app = express();
 const PORT = 3003;
@@ -12,7 +13,7 @@ app.get('/music/:song', (req, res)=>{
     const { song } = req.params
     if ( !song ) return res.status(400).send("Someting went wrong with the request");
 
-    const filePath = `./music/${song}`
+    const filePath = path.join(__dirname, 'music', path.basename(song))
     if( !fs.existsSync(filePath) ) return res.status(404).send("Music not found")
     
     const { range = "bytes=0-"} = req.headers;

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 Simple streaming playground 🎵
 # Endpoints 
 - [GET] `/` Returns a welcome message 🤗
-- [GET] `/muisc/:song` returns by chunks the requested song only if it exists example `/music/Kupla-Orchid.mp3`
+- [GET] `/music/:song` returns by chunks the requested song only if it exists example `/music/Kupla-Orchid.mp3`
 
 ### References
 `LogRocket Tutorial` [video streaming] (https://blog.logrocket.com/build-video-streaming-server-node/)


### PR DESCRIPTION
## Summary
- sanitize song path to avoid directory traversal
- fix endpoint typo in readme

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6848669816608331ad7688a715db5783