### PR TITLE
Add Jest tests for streaming endpoint

### DIFF
--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const request = require('supertest');
+const { spawn } = require('child_process');
+
+let serverProcess;
+
+beforeAll((done) => {
+  const serverPath = path.join(__dirname, 'index.js');
+  serverProcess = spawn('node', [serverPath]);
+
+  serverProcess.stdout.on('data', (data) => {
+    if (data.toString().includes('Express:')) {
+      done();
+    }
+  });
+
+  serverProcess.stderr.on('data', (data) => {
+    console.error(data.toString());
+  });
+});
+
+afterAll(() => {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+});
+
+test('should stream music with partial content', async () => {
+  const res = await request('http://localhost:3003')
+    .get('/music/Kupla-Orchid.mp3')
+    .set('Range', 'bytes=0-');
+
+  expect(res.status).toBe(206);
+  expect(res.headers['content-range']).toBeDefined();
+  expect(res.headers['content-type']).toBeDefined();
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -19,5 +19,9 @@
   "homepage": "https://github.com/developart16/streaming#readme",
   "dependencies": {
     "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.6.4",
+    "supertest": "^6.3.3"
   }
 }


### PR DESCRIPTION
## Summary
- install Jest and Supertest for testing
- add an integration test that starts `index.js` and hits the `/music` endpoint
- configure `npm test` to run Jest

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848692572f88331959202eb97714a08